### PR TITLE
feat: support redux-devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,24 @@ describe('Zoo', () => {
 });
 ```
 
+### Redux Devtools
+
+To enable support for the [Redux Devtools extension](http://extension.remotedev.io/), add the following plugin to your `forRoot` configuration:
+
+```javascript
+import { ReduxDevtoolsPlugin } from 'ngxs';
+
+@NgModule({
+    imports: [
+        NgxsModule.forRoot([
+            ZooStore
+        ], {
+            plugins: [ReduxDevtoolsPlugin]
+        })
+    ]
+})
+```
+
 ### Style Guide
 Below are suggestions for naming and style conventions.
 
@@ -499,7 +517,7 @@ Below are suggestions for naming and style conventions.
 ## Roadmap
 We have lots planned for the future, here is a break down of whats coming next!
 
-- [ ] Devtools
+- [ ] Reactive forms plugin
 - [ ] Localstorage plugin
 - [ ] Reactive forms plugin
 - [ ] Router plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxs",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2101,6 +2101,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2109,14 +2117,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -5169,6 +5169,12 @@
         }
       }
     },
+    "redux-devtools-extension": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz",
+      "integrity": "sha1-4Pmo6N/KfBe+kscSSVijuU6ykR0=",
+      "dev": true
+    },
     "reflect-metadata": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
@@ -5963,6 +5969,15 @@
         "any-observable": "0.2.0"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5972,15 +5987,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lint-staged": "^7.0.0",
     "ng-packagr": "2.0.0-rc.9",
     "prettier": "^1.11.1",
+    "redux-devtools-extension": "^2.13.2",
     "reflect-metadata": "^0.1.10",
     "rxjs": "^5.5.6",
     "tsickle": "^0.27.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export { Select } from './select';
 export { EventStream } from './event-stream';
 export { ofEvent } from './of-event';
 export { NgxsPlugin } from './symbols';
+export { ReduxDevtoolsPlugin } from './plugins/redux-devtools';

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,9 +7,10 @@ import { SelectFactory } from './select';
 import { StateStream } from './state-stream';
 import { PluginManager } from './plugin-manager';
 import { InitStore } from './events/init';
+import { ReduxDevtoolsPlugin } from './plugins/redux-devtools';
 
 @NgModule({
-  providers: [StoreFactory, EventStream, Ngxs, StateStream, SelectFactory, PluginManager]
+  providers: [StoreFactory, EventStream, Ngxs, StateStream, SelectFactory, PluginManager, ReduxDevtoolsPlugin]
 })
 export class NgxsModule {
   static forRoot(stores: any[], options?: NgxsOptions): ModuleWithProviders {
@@ -29,7 +30,8 @@ export class NgxsModule {
         {
           provide: STORE_OPTIONS_TOKEN,
           useValue: options
-        }
+        },
+        ReduxDevtoolsPlugin
       ]
     };
   }

--- a/src/plugins/redux-devtools.ts
+++ b/src/plugins/redux-devtools.ts
@@ -1,0 +1,43 @@
+import { NgxsPlugin } from '../symbols';
+import { Injectable } from '@angular/core';
+
+/**
+ * Interface for the redux-devtools-extension API.
+ */
+export interface DevtoolsExtension {
+  init(state);
+  send(action: string, state?: any);
+  subscribe(fn: (message: string) => void);
+}
+
+/**
+ * Adds support for the Redux Devtools extension:
+ * http://extension.remotedev.io/
+ */
+@Injectable()
+export class ReduxDevtoolsPlugin implements NgxsPlugin {
+  private readonly devtoolsExtension: DevtoolsExtension | null = null;
+  private readonly windowObj: any = typeof window !== 'undefined' ? window : {};
+
+  constructor() {
+    const globalDevtools = this.windowObj['__REDUX_DEVTOOLS_EXTENSION__'] || this.windowObj['devToolsExtension'];
+    if (globalDevtools) {
+      this.devtoolsExtension = globalDevtools.connect() as DevtoolsExtension;
+      /**
+       * todo: initial state sending is not possible due to DI problem in the constructor (injections are undefined).
+       * Possible implementation:
+       * (this.ngxs.select(state => state) as Observable<any>)
+       *   .pipe(first())
+       *   .subscribe(state => this.devtoolsExtension.init(state));
+       */
+      this.devtoolsExtension.init({});
+    }
+  }
+
+  handle(state: any, action: any) {
+    if (!this.devtoolsExtension) {
+      return;
+    }
+    this.devtoolsExtension.send(action.constructor.name, state);
+  }
+}

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -6,8 +6,10 @@ export const LAZY_STORE_TOKEN = new InjectionToken<any>('LAZY_STORE_TOKEN');
 export const LAZY_STORE_OPTIONS_TOKEN = new InjectionToken<any>('LAZY_STORE_OPTIONS_TOKEN');
 export const META_KEY = 'NGXS_META';
 
+export type NgxsPluginConstructor = new (...args: any[]) => NgxsPlugin;
+
 export interface NgxsOptions {
-  plugins: NgxsPlugin[];
+  plugins: NgxsPluginConstructor[];
 }
 
 export interface NgxsPlugin {


### PR DESCRIPTION
Adds support for the redux-devtools.

This fixes also the type for the `plugins` array in the options. It was not possible to provide a class name in the configuration.

Open issue: I'm not able to inject `Ngxs` into the Plugin (it's always `undefined`). So I'm not able to set the initial state.