### PR TITLE
feature/plugins: update plugins with proposed api

### DIFF
--- a/docs/plugins/devtools.md
+++ b/docs/plugins/devtools.md
@@ -1,21 +1,18 @@
 # Redux Devtools
+
 To enable support for the [Redux Devtools extension](http://extension.remotedev.io/),
 add the following plugin to your `forRoot` configuration:
 
 ```javascript
-import { NgxsModule, ReduxDevtoolsPlugin } from 'ngxs';
+import { NgxsModule, ReduxDevtoolsPluginModule } from 'ngxs';
 
 @NgModule({
   imports: [
-    NgxsModule.forRoot([], {
-      plugins: [
-        // `forRoot` is optional if you want to pass options
-        ReduxDevtoolsPlugin.forRoot({
-          disabled: false // Set to true for prod mode
-        })
-      ]
+    NgxsModule.forRoot([]),
+    ReduxDevtoolsPluginModule.forRoot({
+      disabled: false // Set to true for prod mode
     })
   ]
 })
-export class MyModule{}
+export class MyModule {}
 ```

--- a/docs/plugins/localstorage.md
+++ b/docs/plugins/localstorage.md
@@ -1,26 +1,23 @@
 # LocalStorage
+
 You can back your stores with LocalStorage by including the `LocalStoragePlugin` plugin.
 
-```javascript
-import { NgxsModule, LocalStoragePlugin } from 'ngxs';
+```TS
+import { NgxsModule, LocalStoragePluginModule } from 'ngxs';
 
 @NgModule({
   imports: [
-    NgxsModule.forRoot([], {
-      plugins: [
-        // `forRoot`is optional if you want to pass options
-        LocalStoragePlugin.forRoot({
-          // Default, you can pass single string or array of strings
-          // that could be deeply nested too
-          key: '@@STATE',
-          // Custom serializer, defaults to JSON
-          serialize: JSON.stringify,
-          // Custom deserializer, defaults to JSON
-          deserialize: JSON.parse
-        })
-      ]
-    })
+    NgxsModule.forRoot([]),
+    LocalStoragePluginModule.forRoot(
+      // Default, you can pass single string or array of strings
+      // that could be deeply nested too
+      key: '@@STATE',
+      // Custom serializer, defaults to JSON
+      serialize: JSON.stringify,
+      // Custom deserializer, defaults to JSON
+      deserialize: JSON.parse
+    )
   ]
 })
-export class MyModule{}
+export class MyModule {}
 ```

--- a/docs/plugins/logger.md
+++ b/docs/plugins/logger.md
@@ -4,21 +4,17 @@ NGXS comes with a logger plugin for common debugging usage. To take advantage of
 simply import it, configure it and add it to your plugins options.
 
 ```javascript
-import { LoggerPlugin } from 'ngxs';
+import { NgxsModule, LoggerPluginModule } from 'ngxs';
 
 @NgModule({
   imports: [
-    NgxsModule.forRoot([ZooStore], {
-      plugins: [
-        // `forRoot` is optional if you want to pass options
-        LoggerPlugin.forRoot({
-          // custom console.log implement
-          logger: console,
+    NgxsModule.forRoot([ZooStore]),
+    LoggerPluginModule.forRoot({
+      // custom console.log implement
+      logger: console,
 
-          // expand results by default
-          expanded: true
-        })
-      ]
+      // expand results by default
+      expanded: true
     })
   ]
 })

--- a/integration/app/app.module.ts
+++ b/integration/app/app.module.ts
@@ -1,6 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { NgxsModule, LocalStoragePluginModule } from 'ngxs';
+import { NgxsModule } from 'ngxs';
 import { RouterModule } from '@angular/router';
 
 import { TodoStore } from './todo.store';
@@ -9,12 +9,7 @@ import { routes } from './app.routes';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [
-    BrowserModule,
-    RouterModule.forRoot(routes),
-    NgxsModule.forRoot([TodoStore]),
-    LocalStoragePluginModule.forRoot()
-  ],
+  imports: [BrowserModule, RouterModule.forRoot(routes), NgxsModule.forRoot([TodoStore])],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/integration/app/app.module.ts
+++ b/integration/app/app.module.ts
@@ -1,6 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { NgxsModule } from 'ngxs';
+import { NgxsModule, LocalStoragePluginModule } from 'ngxs';
 import { RouterModule } from '@angular/router';
 
 import { TodoStore } from './todo.store';
@@ -9,7 +9,12 @@ import { routes } from './app.routes';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, RouterModule.forRoot(routes), NgxsModule.forRoot([TodoStore])],
+  imports: [
+    BrowserModule,
+    RouterModule.forRoot(routes),
+    NgxsModule.forRoot([TodoStore]),
+    LocalStoragePluginModule.forRoot()
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,11 @@ export { Select } from './select';
 export { EventStream } from './event-stream';
 export { ofEvent } from './of-event';
 export { NgxsPlugin, NgxsPluginFn } from './symbols';
-export { ReduxDevtoolsPlugin, LoggerPlugin, LocalStoragePlugin } from './plugins';
+export {
+  ReduxDevtoolsPlugin,
+  LoggerPlugin,
+  LocalStoragePlugin,
+  LocalStoragePluginModule,
+  LoggerPluginModule,
+  ReduxDevtoolsPluginModule
+} from './plugins';

--- a/src/module.ts
+++ b/src/module.ts
@@ -52,15 +52,10 @@ export class NgxsFeatureModule {
     @SkipSelf()
     private _stateStream: StateStream,
     private _factory: StoreFactory,
-    private _pluginManager: PluginManager,
-    @Optional()
-    @Inject(STORE_OPTIONS_TOKEN)
-    private _storeOptions: NgxsOptions,
     @Optional()
     @Inject(STORE_TOKEN)
     stores: any[]
   ) {
-    this.registerPlugins();
     this.initStores(stores);
   }
 
@@ -75,10 +70,6 @@ export class NgxsFeatureModule {
       // set the state to the current + new
       this._stateStream.next({ ...cur, ...init });
     }
-  }
-
-  registerPlugins() {
-    this._pluginManager.use(this._storeOptions && this._storeOptions.plugins ? this._storeOptions.plugins : []);
   }
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,6 @@
 import { NgModule, ModuleWithProviders, Optional, Inject, SkipSelf } from '@angular/core';
 
-import { STORE_TOKEN, STORE_OPTIONS_TOKEN, NgxsOptions, NGXS_PLUGINS } from './symbols';
+import { STORE_TOKEN, NGXS_PLUGINS } from './symbols';
 import { StoreFactory } from './factory';
 import { EventStream } from './event-stream';
 import { Ngxs } from './ngxs';
@@ -69,7 +69,7 @@ export class NgxsFeatureModule {
 
 @NgModule({})
 export class NgxsModule {
-  static forRoot(stores: any[], options: NgxsOptions = { plugins: [] }): ModuleWithProviders {
+  static forRoot(stores: any[]): ModuleWithProviders {
     return {
       ngModule: NgxsRootModule,
       providers: [
@@ -80,34 +80,24 @@ export class NgxsModule {
         SelectFactory,
         PluginManager,
         stores,
-        options.plugins,
         {
           provide: STORE_TOKEN,
           useValue: stores
-        },
-        {
-          provide: STORE_OPTIONS_TOKEN,
-          useValue: options
         }
       ]
     };
   }
 
-  static forFeature(stores: any[], options: NgxsOptions = { plugins: [] }): ModuleWithProviders {
+  static forFeature(stores: any[]): ModuleWithProviders {
     return {
       ngModule: NgxsFeatureModule,
       providers: [
         stores,
-        options.plugins,
         StoreFactory,
         PluginManager,
         {
           provide: STORE_TOKEN,
           useValue: stores
-        },
-        {
-          provide: STORE_OPTIONS_TOKEN,
-          useValue: options
         }
       ]
     };

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,6 @@
 import { NgModule, ModuleWithProviders, Optional, Inject, SkipSelf } from '@angular/core';
-import { STORE_TOKEN, STORE_OPTIONS_TOKEN, NgxsOptions } from './symbols';
+
+import { STORE_TOKEN, STORE_OPTIONS_TOKEN, NgxsOptions, NGXS_PLUGINS } from './symbols';
 import { StoreFactory } from './factory';
 import { EventStream } from './event-stream';
 import { Ngxs } from './ngxs';
@@ -8,22 +9,19 @@ import { StateStream } from './state-stream';
 import { PluginManager } from './plugin-manager';
 import { InitStore } from './events/init';
 
-@NgModule({})
+@NgModule({
+  providers: [{ provide: NGXS_PLUGINS, useValue: [] }]
+})
 export class NgxsRootModule {
   constructor(
     private _factory: StoreFactory,
     private _stateStream: StateStream,
-    @Optional()
-    @Inject(STORE_OPTIONS_TOKEN)
-    private _storeOptions: NgxsOptions,
-    private _pluginManager: PluginManager,
     store: Ngxs,
     select: SelectFactory,
     @Optional()
     @Inject(STORE_TOKEN)
     stores: any[]
   ) {
-    this.registerPlugins();
     this.initStores(stores);
     store.dispatch(new InitStore());
   }
@@ -38,10 +36,6 @@ export class NgxsRootModule {
       // set the state to the current + new
       this._stateStream.next({ ...cur, ...init });
     }
-  }
-
-  registerPlugins() {
-    this._pluginManager.use(this._storeOptions && this._storeOptions.plugins ? this._storeOptions.plugins : []);
   }
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,6 @@
 import { NgModule, ModuleWithProviders, Optional, Inject, SkipSelf } from '@angular/core';
 
-import { STORE_TOKEN, NGXS_PLUGINS } from './symbols';
+import { STORE_TOKEN } from './symbols';
 import { StoreFactory } from './factory';
 import { EventStream } from './event-stream';
 import { Ngxs } from './ngxs';
@@ -9,9 +9,7 @@ import { StateStream } from './state-stream';
 import { PluginManager } from './plugin-manager';
 import { InitStore } from './events/init';
 
-@NgModule({
-  providers: [{ provide: NGXS_PLUGINS, useValue: null, multi: true }]
-})
+@NgModule()
 export class NgxsRootModule {
   constructor(
     private _factory: StoreFactory,

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,7 +10,7 @@ import { PluginManager } from './plugin-manager';
 import { InitStore } from './events/init';
 
 @NgModule({
-  providers: [{ provide: NGXS_PLUGINS, useValue: [] }]
+  providers: [{ provide: NGXS_PLUGINS, useValue: null, multi: true }]
 })
 export class NgxsRootModule {
   constructor(

--- a/src/plugin-manager.ts
+++ b/src/plugin-manager.ts
@@ -9,22 +9,26 @@ export class PluginManager {
     @Optional()
     @SkipSelf()
     private _parentManager: PluginManager,
-    @Inject(NGXS_PLUGINS) private _plugins: NgxsPlugin[]
+    @Inject(NGXS_PLUGINS)
+    @Optional()
+    private _plugins: NgxsPlugin[]
   ) {
     this.register();
   }
 
   private register() {
-    this.plugins = this._plugins.filter(plugin => plugin).map(plugin => {
-      if (plugin.handle) {
-        return plugin.handle.bind(plugin);
-      } else {
-        return plugin;
-      }
-    });
+    if (this._plugins) {
+      this.plugins = this._plugins.map(plugin => {
+        if (plugin.handle) {
+          return plugin.handle.bind(plugin);
+        } else {
+          return plugin;
+        }
+      });
 
-    if (this._parentManager) {
-      this._parentManager.plugins.push(...this.plugins);
+      if (this._parentManager) {
+        this._parentManager.plugins.push(...this.plugins);
+      }
     }
   }
 }

--- a/src/plugin-manager.ts
+++ b/src/plugin-manager.ts
@@ -10,9 +10,11 @@ export class PluginManager {
     @SkipSelf()
     private _parentManager: PluginManager,
     @Inject(NGXS_PLUGINS) private _plugins: NgxsPlugin[]
-  ) {}
+  ) {
+    this.register();
+  }
 
-  use(plugins: any[]) {
+  private register() {
     this.plugins = this._plugins.map(plugin => {
       if (plugin.handle) {
         return plugin.handle.bind(plugin);

--- a/src/plugin-manager.ts
+++ b/src/plugin-manager.ts
@@ -17,18 +17,20 @@ export class PluginManager {
   }
 
   private register() {
-    if (this._plugins) {
-      this.plugins = this._plugins.map(plugin => {
-        if (plugin.handle) {
-          return plugin.handle.bind(plugin);
-        } else {
-          return plugin;
-        }
-      });
+    if (!this.plugins) {
+      return;
+    }
 
-      if (this._parentManager) {
-        this._parentManager.plugins.push(...this.plugins);
+    this.plugins = this._plugins.map(plugin => {
+      if (plugin.handle) {
+        return plugin.handle.bind(plugin);
+      } else {
+        return plugin;
       }
+    });
+
+    if (this._parentManager) {
+      this._parentManager.plugins.push(...this.plugins);
     }
   }
 }

--- a/src/plugin-manager.ts
+++ b/src/plugin-manager.ts
@@ -17,7 +17,7 @@ export class PluginManager {
   }
 
   private register() {
-    if (!this.plugins) {
+    if (!this._plugins) {
       return;
     }
 

--- a/src/plugin-manager.ts
+++ b/src/plugin-manager.ts
@@ -15,7 +15,7 @@ export class PluginManager {
   }
 
   private register() {
-    this.plugins = this._plugins.map(plugin => {
+    this.plugins = this._plugins.filter(plugin => plugin).map(plugin => {
       if (plugin.handle) {
         return plugin.handle.bind(plugin);
       } else {

--- a/src/plugins/localstorage.ts
+++ b/src/plugins/localstorage.ts
@@ -1,6 +1,6 @@
 import { Injectable, NgModule, ModuleWithProviders, Inject, InjectionToken } from '@angular/core';
 
-import { NgxsPlugin } from '../symbols';
+import { NgxsPlugin, NGXS_PLUGINS } from '../symbols';
 import { getTypeFromInstance } from '../internals';
 
 export interface LocalStoragePluginOptions {
@@ -81,7 +81,11 @@ export class LocalStoragePluginModule {
     return {
       ngModule: LocalStoragePluginModule,
       providers: [
-        LocalStoragePlugin,
+        {
+          provide: NGXS_PLUGINS,
+          useClass: LocalStoragePlugin,
+          multi: true
+        },
         {
           provide: LOCAL_STORAGE_PLUGIN_OPTION,
           useValue: {

--- a/src/plugins/localstorage.ts
+++ b/src/plugins/localstorage.ts
@@ -1,5 +1,6 @@
+import { Injectable, NgModule, ModuleWithProviders, Inject, InjectionToken } from '@angular/core';
+
 import { NgxsPlugin } from '../symbols';
-import { Injectable } from '@angular/core';
 import { getTypeFromInstance } from '../internals';
 
 export interface LocalStoragePluginOptions {
@@ -8,52 +9,45 @@ export interface LocalStoragePluginOptions {
   deserialize(obj: any);
 }
 
-const setValue = (obj, prop, val) => {
+export const LOCAL_STORAGE_PLUGIN_OPTION = new InjectionToken('LOCAL_STORAGE_PLUGIN_OPTION');
+
+const setValue = (obj, prop: string, val) => {
   obj = { ...obj };
+
   const split = prop.split('.');
   const last = split[split.length - 1];
+
   split.reduce((acc, part) => {
     if (part === last) {
       acc[part] = val;
     } else {
       acc[part] = { ...acc[part] };
     }
+
     return acc && acc[part];
   }, obj);
+
   return obj;
 };
 
-const getValue = (obj, prop) => prop.split('.').reduce((acc, part) => acc && acc[part], obj);
+const getValue = (obj, prop: string) => prop.split('.').reduce((acc, part) => acc && acc[part], obj);
 
 @Injectable()
 export class LocalStoragePlugin implements NgxsPlugin {
-  private static _options: LocalStoragePluginOptions | undefined = undefined;
-
-  static forRoot(options) {
-    this._options = options;
-    return this;
-  }
-
-  constructor() {
-    if (!LocalStoragePlugin._options) {
-      LocalStoragePlugin._options = {
-        key: '@@STATE',
-        serialize: JSON.stringify,
-        deserialize: JSON.parse
-      };
-    }
-  }
+  constructor(@Inject(LOCAL_STORAGE_PLUGIN_OPTION) private _options: LocalStoragePluginOptions) {}
 
   handle(state, event, next) {
-    const options = LocalStoragePlugin._options || <any>{};
+    const options = this._options || <any>{};
     const isInitAction = getTypeFromInstance(event) === '@@INIT';
     const keys = Array.isArray(options.key) ? options.key : [options.key];
 
     if (isInitAction) {
       for (const key of keys) {
         let val = localStorage.getItem(key);
+
         if (val !== 'undefined' && val !== null) {
           val = options.deserialize(val);
+
           if (key !== '@@STATE') {
             state = setValue(state, key, val);
           } else {
@@ -68,13 +62,38 @@ export class LocalStoragePlugin implements NgxsPlugin {
     if (!isInitAction) {
       for (const key of keys) {
         let val = state;
+
         if (key !== '@@STATE') {
           val = getValue(state, key);
         }
+
         localStorage.setItem(key, options.serialize(val));
       }
     }
 
     return state;
+  }
+}
+
+@NgModule()
+export class LocalStoragePluginModule {
+  static forRoot(options?: LocalStoragePluginOptions): ModuleWithProviders {
+    return {
+      ngModule: LocalStoragePluginModule,
+      providers: [
+        LocalStoragePlugin,
+        {
+          provide: LOCAL_STORAGE_PLUGIN_OPTION,
+          useValue: {
+            ...{
+              key: '@@STATE',
+              serialize: JSON.stringify,
+              deserialize: JSON.parse
+            },
+            ...options
+          }
+        }
+      ]
+    };
   }
 }

--- a/src/plugins/localstorage.ts
+++ b/src/plugins/localstorage.ts
@@ -97,7 +97,7 @@ export class LocalStoragePluginModule {
         {
           provide: LOCAL_STORAGE_PLUGIN_OPTIONS,
           useValue: {
-            key: '@@STATE',
+            key: options.key || '@@STATE',
             serialize: options.serialize || serialize,
             deserialize: options.deserialize || deserialize
           }

--- a/src/plugins/localstorage.ts
+++ b/src/plugins/localstorage.ts
@@ -4,12 +4,12 @@ import { NgxsPlugin, NGXS_PLUGINS } from '../symbols';
 import { getTypeFromInstance } from '../internals';
 
 export interface LocalStoragePluginOptions {
-  key: string | string[] | undefined;
-  serialize(obj: any);
-  deserialize(obj: any);
+  key?: string | string[] | undefined;
+  serialize?(obj: any);
+  deserialize?(obj: any);
 }
 
-export const LOCAL_STORAGE_PLUGIN_OPTION = new InjectionToken('LOCAL_STORAGE_PLUGIN_OPTION');
+export const LOCAL_STORAGE_PLUGIN_OPTIONS = new InjectionToken('LOCAL_STORAGE_PLUGIN_OPTION');
 
 const setValue = (obj, prop: string, val) => {
   obj = { ...obj };
@@ -34,7 +34,7 @@ const getValue = (obj, prop: string) => prop.split('.').reduce((acc, part) => ac
 
 @Injectable()
 export class LocalStoragePlugin implements NgxsPlugin {
-  constructor(@Inject(LOCAL_STORAGE_PLUGIN_OPTION) private _options: LocalStoragePluginOptions) {}
+  constructor(@Inject(LOCAL_STORAGE_PLUGIN_OPTIONS) private _options: LocalStoragePluginOptions) {}
 
   handle(state, event, next) {
     const options = this._options || <any>{};
@@ -75,9 +75,17 @@ export class LocalStoragePlugin implements NgxsPlugin {
   }
 }
 
+export function serialize(val: any) {
+  return JSON.stringify(val);
+}
+
+export function deserialize(val: any) {
+  return JSON.parse(val);
+}
+
 @NgModule()
 export class LocalStoragePluginModule {
-  static forRoot(options?: LocalStoragePluginOptions): ModuleWithProviders {
+  static forRoot(options: LocalStoragePluginOptions = {}): ModuleWithProviders {
     return {
       ngModule: LocalStoragePluginModule,
       providers: [
@@ -87,14 +95,11 @@ export class LocalStoragePluginModule {
           multi: true
         },
         {
-          provide: LOCAL_STORAGE_PLUGIN_OPTION,
+          provide: LOCAL_STORAGE_PLUGIN_OPTIONS,
           useValue: {
-            ...{
-              key: '@@STATE',
-              serialize: JSON.stringify,
-              deserialize: JSON.parse
-            },
-            ...options
+            key: '@@STATE',
+            serialize: options.serialize || serialize,
+            deserialize: options.deserialize || deserialize
           }
         }
       ]

--- a/src/plugins/logger.ts
+++ b/src/plugins/logger.ts
@@ -1,3 +1,5 @@
+import { Injectable, Inject, InjectionToken, NgModule, ModuleWithProviders } from '@angular/core';
+
 import { NgxsPlugin } from '../symbols';
 
 const repeat = (str, times) => new Array(times + 1).join(str);
@@ -11,24 +13,24 @@ export interface LoggerPluginOptions {
   logger: any;
 }
 
-export class LoggerPlugin implements NgxsPlugin {
-  static _options: LoggerPluginOptions | undefined = undefined;
+export const LOGGER_PLUGIN_OPTIONS = new InjectionToken('LOGGER_PLUGIN_OPTIONS');
 
-  static forRoot(options: LoggerPluginOptions) {
-    this._options = options;
-    return this;
-  }
+@Injectable()
+export class LoggerPlugin implements NgxsPlugin {
+  constructor(@Inject(LOGGER_PLUGIN_OPTIONS) private _options: LoggerPluginOptions) {}
 
   handle(state, event, next) {
-    const options = LoggerPlugin._options || <any>{};
+    const options = this._options || <any>{};
     const logger = options.logger || console;
     const mutationName = event.constructor.type || event.constructor.name;
     const time = new Date();
+
     // tslint:disable-next-line
     const formattedTime = ` @ ${pad(time.getHours(), 2)}:${pad(time.getMinutes(), 2)}:${pad(
       time.getSeconds(),
       2
     )}.${pad(time.getMilliseconds(), 3)}`;
+
     const message = `mutation ${mutationName}${formattedTime}`;
 
     const startMessage = options.collapsed ? logger.groupCollapsed : logger.group;
@@ -40,7 +42,9 @@ export class LoggerPlugin implements NgxsPlugin {
     }
 
     logger.log('%c prev state', 'color: #9E9E9E; font-weight: bold', state);
+
     const nextState = next(state, event);
+
     logger.log('%c next state', 'color: #4CAF50; font-weight: bold', nextState);
 
     try {
@@ -48,5 +52,27 @@ export class LoggerPlugin implements NgxsPlugin {
     } catch (e) {
       logger.log('—— log end ——');
     }
+  }
+}
+
+@NgModule()
+export class LoggerPluginModule {
+  static forRoot(options: LoggerPluginOptions): ModuleWithProviders {
+    return {
+      ngModule: LoggerPluginModule,
+      providers: [
+        LoggerPlugin,
+        {
+          provide: LOGGER_PLUGIN_OPTIONS,
+          useValue: {
+            ...{
+              logger: console,
+              collapsed: false
+            },
+            ...options
+          }
+        }
+      ]
+    };
   }
 }

--- a/src/plugins/logger.ts
+++ b/src/plugins/logger.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject, InjectionToken, NgModule, ModuleWithProviders } from '@angular/core';
 
-import { NgxsPlugin } from '../symbols';
+import { NgxsPlugin, NGXS_PLUGINS } from '../symbols';
 
 const repeat = (str, times) => new Array(times + 1).join(str);
 const pad = (num, maxLength) => repeat('0', maxLength - num.toString().length) + num;
@@ -61,7 +61,11 @@ export class LoggerPluginModule {
     return {
       ngModule: LoggerPluginModule,
       providers: [
-        LoggerPlugin,
+        {
+          provide: NGXS_PLUGINS,
+          useClass: LoggerPlugin,
+          multi: true
+        },
         {
           provide: LOGGER_PLUGIN_OPTIONS,
           useValue: {

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -16,6 +16,8 @@ export interface NgxsPlugin {
   handle(state: any, mutation: any, next: NgxsNextPluginFn): any;
 }
 
+export const NGXS_PLUGINS = new InjectionToken('NGXS_PLUGINS');
+
 export type NgxsPluginFn = (state: any, mutation: any, next: NgxsNextPluginFn) => any;
 
 export interface StoreOptions {


### PR DESCRIPTION
@amcdnl putting the work here so you can see it. closes #16 

The API will use a plugins DI token for the plugin classes and each plugin will use it's own *_OPTIONS token to configure the plugin. The plugin can then be provided either manually (not recommended) or use the plugin module with a *.forRoot() method.

```TS
@NgModule({
  imports: [
    NgxsModule.forRoot([TodoStore]),
    LocalStoragePluginModule.forRoot({ ... })
  ]
})
```

the example forRoot implementation for the localstorage plugin looks like:

```TS
export function serialize(val: any) {
  return JSON.stringify(val);
}

export function deserialize(val: any) {
  return JSON.parse(val);
}

@NgModule()
export class LocalStoragePluginModule {
  static forRoot(options: LocalStoragePluginOptions = {}): ModuleWithProviders {
    return {
      ngModule: LocalStoragePluginModule,
      providers: [
        {
          provide: NGXS_PLUGINS,
          useClass: LocalStoragePlugin,
          multi: true
        },
        {
          provide: LOCAL_STORAGE_PLUGIN_OPTIONS,
          useValue: {
            key: options.key || '@@STATE',
            serialize: options.serialize || serialize,
            deserialize: options.deserialize || deserialize
          }
        }
      ]
    };
  }
}
```

NOTE: the important thing here is those Injection Tokens. It doesn't matter how the plugin author provides them. (ex: PluginModule, providePlugin(), etc)