### PR TITLE
fix(core): class selector

### DIFF
--- a/integration/app/app.component.spec.ts
+++ b/integration/app/app.component.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { AppModule } from './app.module';
+import { AppComponent } from './app.component';
+
+describe('AppComponent', () => {
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppModule, RouterTestingModule]
+    });
+
+    fixture = TestBed.createComponent(AppComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should add a todo', () => {
+    component.addTodo('Get Milk');
+    component.addTodo('Clean Bathroom');
+
+    component.todos$.subscribe(state => {
+      expect(state.todo.length).toBe(2);
+    });
+  });
+
+  it('should remove a todo', () => {
+    component.addTodo('Get Milk');
+    component.addTodo('Clean Bathroom');
+    component.removeTodo(1);
+
+    component.todos$.subscribe(state => {
+      expect(state.todo.length).toBe(1);
+      expect(state.todo[0]).toBe('Get Milk');
+    });
+  });
+});

--- a/integration/app/app.component.ts
+++ b/integration/app/app.component.ts
@@ -2,8 +2,7 @@ import { Component, ViewEncapsulation } from '@angular/core';
 import { Store, Select } from 'ngxs';
 import { Observable } from 'rxjs/Observable';
 
-import { AddTodo, RemoveTodo } from './todo.state';
-import { AppState } from './app.state';
+import { AddTodo, RemoveTodo, TodosState, TodoState } from './todo.state';
 
 @Component({
   selector: 'app-root',
@@ -25,8 +24,9 @@ import { AppState } from './app.state';
   encapsulation: ViewEncapsulation.None
 })
 export class AppComponent {
-  @Select((state: AppState) => state.todos.todo)
-  todos$: Observable<string[]>;
+  @Select(TodosState) todos$: Observable<{ todo: string[] }>;
+
+  @Select(TodoState) foo$: Observable<string[]>;
 
   constructor(private store: Store) {}
 

--- a/integration/app/app.module.ts
+++ b/integration/app/app.module.ts
@@ -1,9 +1,9 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { NgxsModule, ReduxDevtoolsPluginModule } from 'ngxs';
 import { RouterModule } from '@angular/router';
-import { environment } from '../environments/environment';
+import { NgxsModule, ReduxDevtoolsPluginModule } from 'ngxs';
 
+import { environment } from '../environments/environment';
 import { AppComponent } from './app.component';
 import { routes } from './app.routes';
 import { states } from './app.state';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "ng serve --aot",
     "test": "ng test",
-    "test:integration": "npm run build && npm link ./dist && ng build --preserve-symlinks --app integration --prod",
+    "test:integration":
+      "npm run build && npm link ./dist && ng build -ps --app 1 --prod && ng test -ps --app 1 --prod --sr",
     "test:ci": "ng test -cc --browsers ChromeHeadless --single-run -cc && npm run test:integration",
     "build": "ng-packagr -p package.json",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
@@ -16,18 +17,7 @@
     "type": "git",
     "url": "git+https://amcdnl@github.com/amcdnl/ngxs.git"
   },
-  "keywords": [
-    "ngrx",
-    "redux",
-    "state",
-    "rxjs",
-    "angular",
-    "ngx",
-    "angular2",
-    "cqrs",
-    "store",
-    "state-mangement"
-  ],
+  "keywords": ["ngrx", "redux", "state", "rxjs", "angular", "ngx", "angular2", "cqrs", "store", "state-mangement"],
   "author": "Austin McDaniel",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "start": "ng serve --aot",
     "test": "ng test",
     "test:integration":
-      "npm run build && npm link ./dist && ng test --preserve-symlinks --app 1 --sr &&  ng build --preserve-symlinks --app 1 --prod",
-    "test:ci": "ng test -cc --browsers ChromeHeadless --single-run -cc && npm run test:integration",
+      "npm run build && npm link ./dist && ng test --preserve-symlinks --app 1 -sr --browsers ChromeHeadless &&  ng build --preserve-symlinks --app 1 --prod",
+    "test:ci": "ng test -cc --browsers ChromeHeadless --single-run && npm run test:integration",
     "build": "ng-packagr -p package.json",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
     "prettier": "prettier --write \"**/*.ts\""

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve --aot",
     "test": "ng test",
     "test:integration":
-      "npm run build && npm link ./dist && ng build -ps --app 1 --prod && ng test -ps --app 1 --prod --sr",
+      "npm run build && npm link ./dist && ng build --preserve-symlinks --app 1 --prod && ng test --preserve-symlinks --app 1 --sr",
     "test:ci": "ng test -cc --browsers ChromeHeadless --single-run -cc && npm run test:integration",
     "build": "ng-packagr -p package.json",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve --aot",
     "test": "ng test",
     "test:integration":
-      "npm run build && npm link ./dist && ng build --preserve-symlinks --app 1 --prod && ng test --preserve-symlinks --app 1 --sr",
+      "npm run build && npm link ./dist && ng test --preserve-symlinks --app 1 --sr &&  ng build --preserve-symlinks --app 1 --prod",
     "test:ci": "ng test -cc --browsers ChromeHeadless --single-run -cc && npm run test:integration",
     "build": "ng-packagr -p package.json",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -1,19 +1,23 @@
 import { META_KEY } from './symbols';
 
 export interface MetaDataModel {
+  name: string;
   actions: any;
   defaults: any;
+  path: string;
   children: any[];
 }
 
 /**
  * Ensures metadata is attached to the klass and returns it.
  */
-export function ensureStoreMetadata(target) {
+export function ensureStoreMetadata(target): MetaDataModel {
   if (!target.hasOwnProperty(META_KEY)) {
     const defaultMetadata: MetaDataModel = {
+      name: null,
       actions: {},
       defaults: {},
+      path: null,
       children: []
     };
 

--- a/src/select.ts
+++ b/src/select.ts
@@ -34,6 +34,18 @@ export function Select(selectorOrFeature?, ...paths: string[]) {
       return store.select(fn);
     };
 
+    const createSelector = () => {
+      if (typeof selectorOrFeature === 'string') {
+        const propsArray = paths.length ? [selectorOrFeature, ...paths] : selectorOrFeature.split('.');
+
+        return fastPropGetter(propsArray);
+      } else if (selectorOrFeature[META_KEY] && selectorOrFeature[META_KEY].path) {
+        return fastPropGetter(selectorOrFeature[META_KEY].path.split('.'));
+      } else {
+        return selectorOrFeature;
+      }
+    };
+
     if (target[selectorFnName]) {
       throw new Error('You cannot use @Select decorator and a ' + selectorFnName + ' property.');
     }
@@ -47,19 +59,7 @@ export function Select(selectorOrFeature?, ...paths: string[]) {
 
       Object.defineProperty(target, name, {
         get: function() {
-          let fn;
-
-          if (typeof selectorOrFeature === 'string') {
-            const propsArray = paths.length ? [selectorOrFeature, ...paths] : selectorOrFeature.split('.');
-
-            fn = fastPropGetter(propsArray);
-          } else if (selectorOrFeature[META_KEY] && selectorOrFeature[META_KEY].path) {
-            fn = fastPropGetter(selectorOrFeature[META_KEY].path.split('.'));
-          } else {
-            fn = selectorOrFeature;
-          }
-
-          return this[selectorFnName] || (this[selectorFnName] = createSelect.apply(this, [fn]));
+          return this[selectorFnName] || (this[selectorFnName] = createSelect.apply(this, [createSelector()]));
         },
         enumerable: true,
         configurable: true

--- a/src/select.ts
+++ b/src/select.ts
@@ -29,8 +29,8 @@ export function Select(selectorOrFeature?, ...paths: string[]) {
       const propsArray = paths.length ? [selectorOrFeature, ...paths] : selectorOrFeature.split('.');
 
       fn = fastPropGetter(propsArray);
-    } else if (selectorOrFeature[META_KEY] && selectorOrFeature[META_KEY].name) {
-      fn = fastPropGetter(selectorOrFeature[META_KEY].name.split('.'));
+    } else if (selectorOrFeature[META_KEY] && selectorOrFeature[META_KEY].path) {
+      fn = fastPropGetter(selectorOrFeature[META_KEY].path.split('.'));
     } else {
       fn = selectorOrFeature;
     }

--- a/src/spec/select.spec.ts
+++ b/src/spec/select.spec.ts
@@ -1,28 +1,43 @@
 import { TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+
 import { NgxsModule } from '../module';
 import { Select } from '../select';
 import { State } from '../state';
 
 describe('Select', () => {
+  interface SubSubStateModel {
+    name: string;
+  }
+
+  interface SubStateModel {
+    hello: boolean;
+    world: boolean;
+    subSubProperty?: SubSubStateModel;
+  }
+
   interface StateModel {
     foo: string;
     bar: string;
     subProperty?: SubStateModel;
   }
 
-  interface SubStateModel {
-    hello: boolean;
-    world: boolean;
-  }
+  @State<SubSubStateModel>({
+    name: 'baz',
+    defaults: {
+      name: 'Danny'
+    }
+  })
+  class MySubSubState {}
 
   @State<SubStateModel>({
     name: 'boo',
     defaults: {
       hello: true,
       world: true
-    }
+    },
+    children: [MySubSubState]
   })
   class MySubState {}
 
@@ -43,6 +58,7 @@ describe('Select', () => {
   class StringSelectComponent {
     @Select('counter') state: Observable<StateModel>;
     @Select('counter.boo') subState: Observable<SubStateModel>;
+    @Select('counter.boo.baz') subSubState: Observable<SubSubStateModel>;
   }
 
   @Component({
@@ -52,11 +68,12 @@ describe('Select', () => {
   class StoreSelectComponent {
     @Select(MyState) state: Observable<StateModel>;
     @Select(MySubState) subState: Observable<SubStateModel>;
+    @Select(MySubSubState) subSubState: Observable<SubSubStateModel>;
   }
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([MyState, MySubState])],
+      imports: [NgxsModule.forRoot([MyState, MySubState, MySubSubState])],
       declarations: [StringSelectComponent, StoreSelectComponent]
     });
   });
@@ -86,6 +103,10 @@ describe('Select', () => {
     comp.componentInstance.subState.subscribe(state => {
       expect(state.hello).toBe(true);
       expect(state.world).toBe(true);
+    });
+
+    comp.componentInstance.subSubState.subscribe(state => {
+      expect(state.name).toBe('Danny');
     });
   });
 });

--- a/src/spec/select.spec.ts
+++ b/src/spec/select.spec.ts
@@ -9,16 +9,32 @@ describe('Select', () => {
   interface StateModel {
     foo: string;
     bar: string;
+    subProperty?: SubStateModel;
   }
+
+  interface SubStateModel {
+    hello: boolean;
+    world: boolean;
+  }
+
+  @State<SubStateModel>({
+    name: 'boo',
+    defaults: {
+      hello: true,
+      world: true
+    }
+  })
+  class MySubState {}
 
   @State<StateModel>({
     name: 'counter',
     defaults: {
       foo: 'Hello',
       bar: 'World'
-    }
+    },
+    children: [MySubState]
   })
-  class MyStore {}
+  class MyState {}
 
   @Component({
     selector: 'my-component-0',
@@ -26,6 +42,7 @@ describe('Select', () => {
   })
   class StringSelectComponent {
     @Select('counter') state: Observable<StateModel>;
+    @Select('counter.boo') subState: Observable<SubStateModel>;
   }
 
   @Component({
@@ -33,31 +50,42 @@ describe('Select', () => {
     template: ''
   })
   class StoreSelectComponent {
-    @Select(MyStore) state: Observable<StateModel>;
+    @Select(MyState) state: Observable<StateModel>;
+    @Select(MySubState) subState: Observable<SubStateModel>;
   }
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([MyStore])],
+      imports: [NgxsModule.forRoot([MyState, MySubState])],
       declarations: [StringSelectComponent, StoreSelectComponent]
     });
   });
 
   it('should select the correct state using string', () => {
+    const comp = TestBed.createComponent(StringSelectComponent);
+
+    comp.componentInstance.state.subscribe(state => {
+      expect(state.foo).toBe('Hello');
+      expect(state.bar).toBe('World');
+    });
+
+    comp.componentInstance.subState.subscribe(state => {
+      expect(state.hello).toBe(true);
+      expect(state.world).toBe(true);
+    });
+  });
+
+  it('should select the correct state using a state class', () => {
     const comp = TestBed.createComponent(StoreSelectComponent);
 
     comp.componentInstance.state.subscribe(state => {
       expect(state.foo).toBe('Hello');
       expect(state.bar).toBe('World');
     });
-  });
 
-  it('should select the correct state using a store class', () => {
-    const comp = TestBed.createComponent(StringSelectComponent);
-
-    comp.componentInstance.state.subscribe(state => {
-      expect(state.foo).toBe('Hello');
-      expect(state.bar).toBe('World');
+    comp.componentInstance.subState.subscribe(state => {
+      expect(state.hello).toBe(true);
+      expect(state.world).toBe(true);
     });
   });
 });

--- a/src/spec/select.spec.ts
+++ b/src/spec/select.spec.ts
@@ -90,6 +90,10 @@ describe('Select', () => {
       expect(state.hello).toBe(true);
       expect(state.world).toBe(true);
     });
+
+    comp.componentInstance.subSubState.subscribe(state => {
+      expect(state.name).toBe('Danny');
+    });
   });
 
   it('should select the correct state using a state class', () => {

--- a/src/state-factory.ts
+++ b/src/state-factory.ts
@@ -1,4 +1,6 @@
 import { Injector, Injectable, SkipSelf, Optional } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
 import { META_KEY } from './symbols';
 import {
   getTypeFromInstance,
@@ -9,7 +11,6 @@ import {
   setValue,
   getValue
 } from './internals';
-import { Observable } from 'rxjs/Observable';
 
 @Injectable()
 export class StateFactory {
@@ -47,6 +48,8 @@ export class StateFactory {
       const depth = depths[name];
       const { actions } = klass[META_KEY];
       let { defaults } = klass[META_KEY];
+
+      klass[META_KEY].path = depth;
 
       // ensure our store hasn't already been added
       const has = this.states.find(s => s.name === name);

--- a/src/state-factory.ts
+++ b/src/state-factory.ts
@@ -44,8 +44,6 @@ export class StateFactory {
         throw new Error('States must be decorated with @State() decorator');
       }
 
-      klass[META_KEY].path = depths[name];
-
       const depth = depths[name];
       const { actions } = klass[META_KEY];
       let { defaults } = klass[META_KEY];

--- a/src/state-factory.ts
+++ b/src/state-factory.ts
@@ -36,11 +36,15 @@ export class StateFactory {
     const nameGraph = nameToState(states);
 
     const mappedStores = [];
+
     for (const name of sortedStates) {
       const klass = nameGraph[name];
+
       if (!klass[META_KEY]) {
         throw new Error('States must be decorated with @State() decorator');
       }
+
+      klass[META_KEY].path = depths[name];
 
       const depth = depths[name];
       const { actions } = klass[META_KEY];
@@ -48,6 +52,7 @@ export class StateFactory {
 
       // ensure our store hasn't already been added
       const has = this.states.find(s => s.name === name);
+
       if (has) {
         throw new Error(`Store has already been added: ${name}`);
       }
@@ -60,6 +65,7 @@ export class StateFactory {
       }
 
       const instance = this._injector.get(klass);
+
       mappedStores.push({
         actions,
         instance,
@@ -70,6 +76,7 @@ export class StateFactory {
     }
 
     this.states.push(...mappedStores);
+
     return mappedStores;
   }
 

--- a/src/state-factory.ts
+++ b/src/state-factory.ts
@@ -9,7 +9,8 @@ import {
   findFullParentPath,
   nameToState,
   setValue,
-  getValue
+  getValue,
+  MetaDataModel
 } from './internals';
 
 @Injectable()
@@ -46,10 +47,10 @@ export class StateFactory {
       }
 
       const depth = depths[name];
-      const { actions } = klass[META_KEY];
-      let { defaults } = klass[META_KEY];
+      const { actions } = klass[META_KEY] as MetaDataModel;
+      let { defaults } = klass[META_KEY] as MetaDataModel;
 
-      klass[META_KEY].path = depth;
+      (klass[META_KEY] as MetaDataModel).path = depth;
 
       // ensure our store hasn't already been added
       const has = this.states.find(s => s.name === name);

--- a/src/state.ts
+++ b/src/state.ts
@@ -37,13 +37,5 @@ export function State<T>(options: StoreOptions<T>) {
     } else {
       meta.name = getNameFromClass(target.name);
     }
-
-    meta.path = meta.name;
-
-    if (meta.children && meta.children.length) {
-      meta.children.forEach(child => {
-        child[META_KEY].path = meta.name + '.' + child[META_KEY].path;
-      });
-    }
   };
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -37,5 +37,13 @@ export function State<T>(options: StoreOptions<T>) {
     } else {
       meta.name = getNameFromClass(target.name);
     }
+
+    meta.path = meta.name;
+
+    if (meta.children && meta.children.length) {
+      meta.children.forEach(child => {
+        child[META_KEY].path = meta.name + '.' + child[META_KEY].path;
+      });
+    }
   };
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -23,6 +23,7 @@ export function State<T>(options: StoreOptions<T>) {
     // Handle inheritance
     if (target.__proto__.hasOwnProperty(META_KEY)) {
       const parentMeta = target.__proto__[META_KEY];
+
       meta.actions = {
         ...meta.actions,
         ...parentMeta.actions


### PR DESCRIPTION
Fixes issue where selecting substate with a class would return undefined. A state "path" is now added to metadata when children are present

The StateFactory now adds the path property to each class on init.

NOTE: may have uncovered another issue with sub states if you include the substate in the forRoot method BEFORE the root