### PR TITLE
fix(core): inferring state name breaks with uglify

### DIFF
--- a/src/spec/action.spec.ts
+++ b/src/spec/action.spec.ts
@@ -7,7 +7,9 @@ describe('Action', () => {
     class Action1 {}
     class Action2 {}
 
-    @State({})
+    @State({
+      name: 'bar'
+    })
     class BarStore {
       @Action([Action1, Action2])
       foo({ setState }) {

--- a/src/spec/state.spec.ts
+++ b/src/spec/state.spec.ts
@@ -3,22 +3,6 @@ import { State } from '../state';
 import { Action } from '../action';
 
 describe('Store', () => {
-  it('infers correct name', () => {
-    @State({})
-    class BarState {}
-
-    const meta = ensureStoreMetadata(BarState);
-    expect(meta.name).toBe('bar');
-  });
-
-  it('infers correct name without suffix', () => {
-    @State({})
-    class Bar {}
-
-    const meta = ensureStoreMetadata(Bar);
-    expect(meta.name).toBe('bar');
-  });
-
   it('describes correct name', () => {
     @State({
       name: 'moo'

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,18 +2,6 @@ import { ensureStoreMetadata } from './internals';
 import { StoreOptions, META_KEY } from './symbols';
 
 /**
- * Gets the name of the constructor and remove suffix if applicable.
- */
-const getNameFromClass = name => {
-  const hasSuffix = name.slice(name.length - 5, name.length) === 'State';
-  if (hasSuffix) {
-    return name.slice(0, 1).toLowerCase() + name.slice(1, name.length - 5);
-  } else {
-    return name.slice(0, 1).toLowerCase() + name.slice(1, name.length);
-  }
-};
-
-/**
  * Decorates a class with ngxs state information.
  */
 export function State<T>(options: StoreOptions<T>) {
@@ -32,11 +20,6 @@ export function State<T>(options: StoreOptions<T>) {
 
     meta.children = options.children;
     meta.defaults = options.defaults;
-
-    if (options.name) {
-      meta.name = options.name;
-    } else {
-      meta.name = getNameFromClass(target.name);
-    }
+    meta.name = options.name;
   };
 }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -29,7 +29,7 @@ export const NGXS_PLUGINS = new InjectionToken('NGXS_PLUGINS');
 export type NgxsPluginFn = (state: any, mutation: any, next: NgxsNextPluginFn) => any;
 
 export interface StoreOptions<T> {
-  name?: string;
+  name: string;
   defaults?: T;
   children?: any[];
 }


### PR DESCRIPTION
this PR makes "name" a required property for the state decorator to help avoid issues with minification. fixes #72 