### PR TITLE
refactor(plugins): ngxs prefix

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -4,7 +4,7 @@ Next let's talk about plugins. Similar to Redux's meta reducers, we have
 a plugins interface that allows you to build a global plugin for your state.
 
 All you have to do is provide a class to the `NGXS_PLUGINS` token.
-If your plugins has options associated with it, we suggest defining an injection token 
+If your plugins has options associated with it, we suggest defining an injection token
 and then a `forRoot` method on your module
 
 Let's take a basic example of a logger:
@@ -13,7 +13,7 @@ Let's take a basic example of a logger:
 import { Injectable, Inject, NgModule } from '@angular/core';
 import { NgxsPlugin, NGXS_PLUGINS } from 'ngxs';
 
-export const LOGGER_PLUGIN_OPTIONS = new InjectionToken('LOGGER_PLUGIN_OPTIONS');
+export const NGXS_LOGGER_PLUGIN_OPTIONS = new InjectionToken('NGXS_LOGGER_PLUGIN_OPTIONS');
 
 @Injectable()
 export class LoggerPlugin implements NgxsPlugin {
@@ -28,10 +28,10 @@ export class LoggerPlugin implements NgxsPlugin {
 }
 
 @NgModule()
-export class LoggerPluginModule {
+export class NgxsLoggerPluginModule {
   static forRoot(config?: any): ModuleWithProviders = {
     return {
-      ngModule: LoggerPluginModule,
+      ngModule: NgxsLoggerPluginModule,
       providers: [
         {
           provide: NGXS_PLUGINS,
@@ -39,7 +39,7 @@ export class LoggerPluginModule {
           multi: true  
         },
         {
-          provide: LOGGER_PLUGIN_OPTIONS,
+          provide: NGXS_LOGGER_PLUGIN_OPTIONS,
           useValue: config
         }
       ]
@@ -67,10 +67,7 @@ in the module hookup like:
 
 ```javascript
 @NgModule({
-  imports: [
-    NgxsModule.forRoot([ZooStore]),
-    LoggerPluginModule.forRoot({})
-  ]
+  imports: [NgxsModule.forRoot([ZooStore]), NgxsLoggerPluginModule.forRoot({})]
 })
 export class MyModule {}
 ```

--- a/docs/plugins/devtools.md
+++ b/docs/plugins/devtools.md
@@ -4,12 +4,12 @@ To enable support for the [Redux Devtools extension](http://extension.remotedev.
 add the following plugin to your `forRoot` configuration:
 
 ```javascript
-import { NgxsModule, ReduxDevtoolsPluginModule } from 'ngxs';
+import { NgxsModule, NgxsReduxDevtoolsPluginModule } from 'ngxs';
 
 @NgModule({
   imports: [
     NgxsModule.forRoot([]),
-    ReduxDevtoolsPluginModule.forRoot({
+    NgxsReduxDevtoolsPluginModule.forRoot({
       /**
        * Disable the devtools, useful to disabling during production
        */

--- a/docs/plugins/localstorage.md
+++ b/docs/plugins/localstorage.md
@@ -1,20 +1,20 @@
 # LocalStorage
 
-You can back your stores with LocalStorage by including the `LocalStoragePlugin` plugin.
+You can back your stores with LocalStorage by including the `NgxsLocalStoragePlugin` plugin.
 
 ```TS
-import { NgxsModule, LocalStoragePluginModule, StorageStrategy } from 'ngxs';
+import { NgxsModule, NgxsLocalStoragePluginModule, StorageStrategy } from 'ngxs';
 
 @NgModule({
   imports: [
     NgxsModule.forRoot([]),
-    LocalStoragePluginModule.forRoot({
+    NgxsLocalStoragePluginModule.forRoot({
       /**
        * Default key to persist. You can pass a string or array of string
        * that can be deeply nested via dot notation.
        */
       key: '@@STATE',
-      
+
       /**
        * Storage strategy to use. Thie defaults to localStorage but you
        * can pass sessionStorage or anything that implements the localStorage API.

--- a/docs/plugins/logger.md
+++ b/docs/plugins/logger.md
@@ -4,12 +4,12 @@ NGXS comes with a logger plugin for common debugging usage. To take advantage of
 simply import it, configure it and add it to your plugins options.
 
 ```javascript
-import { NgxsModule, LoggerPluginModule } from 'ngxs';
+import { NgxsModule, NgxsLoggerPluginModule } from 'ngxs';
 
 @NgModule({
   imports: [
     NgxsModule.forRoot([ZooStore]),
-    LoggerPluginModule.forRoot({
+    NgxsLoggerPluginModule.forRoot({
       /**
        * Logger to implement. Defaults to console.
        */

--- a/integration/app/app.module.ts
+++ b/integration/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { NgxsModule, ReduxDevtoolsPluginModule } from 'ngxs';
+import { NgxsModule, NgxsReduxDevtoolsPluginModule } from 'ngxs';
 
 import { environment } from '../environments/environment';
 import { AppComponent } from './app.component';
@@ -14,7 +14,7 @@ import { states } from './app.state';
     BrowserModule,
     RouterModule.forRoot(routes),
     NgxsModule.forRoot(states),
-    ReduxDevtoolsPluginModule.forRoot({
+    NgxsReduxDevtoolsPluginModule.forRoot({
       disabled: environment.production
     })
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,6 @@ export { ofAction } from './of-action';
 export { NgxsPlugin, NgxsPluginFn, StateContext } from './symbols';
 export { Selector } from './selector';
 
-export { ReduxDevtoolsPlugin, ReduxDevtoolsPluginModule } from './plugins/devtools/index';
-export { LoggerPlugin, LoggerPluginModule } from './plugins/logger/index';
-export { LocalStoragePlugin, LocalStoragePluginModule } from './plugins/localstorage/index';
+export { NgxsReduxDevtoolsPlugin, NgxsReduxDevtoolsPluginModule } from './plugins/devtools/index';
+export { NgxsLoggerPlugin, NgxsLoggerPluginModule } from './plugins/logger/index';
+export { NgxsLocalStoragePlugin, NgxsLocalStoragePluginModule } from './plugins/localstorage/index';

--- a/src/plugins/devtools/devtools.module.ts
+++ b/src/plugins/devtools/devtools.module.ts
@@ -1,23 +1,16 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { NGXS_PLUGINS } from '../../symbols';
-import { DevtoolsOptions, DEVTOOLS_OPTIONS } from './symbols';
-import { ReduxDevtoolsPlugin } from './devtools.plugin';
+import { NgxsDevtoolsOptions, NGXS_DEVTOOLS_OPTIONS } from './symbols';
+import { NgxsReduxDevtoolsPlugin } from './devtools.plugin';
 
 @NgModule()
-export class ReduxDevtoolsPluginModule {
-  static forRoot(options?: DevtoolsOptions): ModuleWithProviders {
+export class NgxsReduxDevtoolsPluginModule {
+  static forRoot(options?: NgxsDevtoolsOptions): ModuleWithProviders {
     return {
-      ngModule: ReduxDevtoolsPluginModule,
+      ngModule: NgxsReduxDevtoolsPluginModule,
       providers: [
-        {
-          provide: NGXS_PLUGINS,
-          useClass: ReduxDevtoolsPlugin,
-          multi: true
-        },
-        {
-          provide: DEVTOOLS_OPTIONS,
-          useValue: options
-        }
+        { provide: NGXS_PLUGINS, useClass: NgxsReduxDevtoolsPlugin, multi: true },
+        { provide: NGXS_DEVTOOLS_OPTIONS, useValue: options }
       ]
     };
   }

--- a/src/plugins/devtools/devtools.plugin.ts
+++ b/src/plugins/devtools/devtools.plugin.ts
@@ -1,7 +1,7 @@
 import { NgxsPlugin } from '../../symbols';
 import { getTypeFromInstance } from '../../internals';
 import { Injectable, Inject } from '@angular/core';
-import { DevtoolsExtension, DevtoolsOptions, DEVTOOLS_OPTIONS } from './symbols';
+import { NgxsDevtoolsExtension, NgxsDevtoolsOptions, NGXS_DEVTOOLS_OPTIONS } from './symbols';
 import { tap } from 'rxjs/operators';
 
 /**
@@ -9,15 +9,15 @@ import { tap } from 'rxjs/operators';
  * http://extension.remotedev.io/
  */
 @Injectable()
-export class ReduxDevtoolsPlugin implements NgxsPlugin {
-  private readonly devtoolsExtension: DevtoolsExtension | null = null;
+export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
+  private readonly devtoolsExtension: NgxsDevtoolsExtension | null = null;
   private readonly windowObj: any = typeof window !== 'undefined' ? window : {};
 
-  constructor(@Inject(DEVTOOLS_OPTIONS) private _options: DevtoolsOptions) {
+  constructor(@Inject(NGXS_DEVTOOLS_OPTIONS) private _options: NgxsDevtoolsOptions) {
     const globalDevtools = this.windowObj['__REDUX_DEVTOOLS_EXTENSION__'] || this.windowObj['devToolsExtension'];
 
     if (globalDevtools) {
-      this.devtoolsExtension = globalDevtools.connect() as DevtoolsExtension;
+      this.devtoolsExtension = globalDevtools.connect() as NgxsDevtoolsExtension;
     }
   }
 

--- a/src/plugins/devtools/index.ts
+++ b/src/plugins/devtools/index.ts
@@ -1,2 +1,2 @@
-export { ReduxDevtoolsPluginModule } from './devtools.module';
-export { ReduxDevtoolsPlugin } from './devtools.plugin';
+export { NgxsReduxDevtoolsPluginModule } from './devtools.module';
+export { NgxsReduxDevtoolsPlugin } from './devtools.plugin';

--- a/src/plugins/devtools/symbols.ts
+++ b/src/plugins/devtools/symbols.ts
@@ -3,14 +3,14 @@ import { InjectionToken } from '@angular/core';
 /**
  * Interface for the redux-devtools-extension API.
  */
-export interface DevtoolsExtension {
+export interface NgxsDevtoolsExtension {
   init(state);
   send(action: string, state?: any);
   subscribe(fn: (message: string) => void);
 }
 
-export interface DevtoolsOptions {
+export interface NgxsDevtoolsOptions {
   disabled: boolean;
 }
 
-export const DEVTOOLS_OPTIONS = new InjectionToken('DEVTOOLS_OPTIONS');
+export const NGXS_DEVTOOLS_OPTIONS = new InjectionToken('NGXS_DEVTOOLS_OPTIONS');

--- a/src/plugins/localstorage/index.ts
+++ b/src/plugins/localstorage/index.ts
@@ -1,2 +1,2 @@
-export { LocalStoragePluginModule } from './localstorage.module';
-export { LocalStoragePlugin } from './localstorage.plugin';
+export { NgxsLocalStoragePluginModule } from './localstorage.module';
+export { NgxsLocalStoragePlugin } from './localstorage.plugin';

--- a/src/plugins/localstorage/localstorage.module.ts
+++ b/src/plugins/localstorage/localstorage.module.ts
@@ -1,23 +1,23 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 
 import { NGXS_PLUGINS } from '../../symbols';
-import { LocalStoragePlugin } from './localstorage.plugin';
+import { NgxsLocalStoragePlugin } from './localstorage.plugin';
 import { serialize, deserialize } from './utils';
-import { LocalStoragePluginOptions, LOCAL_STORAGE_PLUGIN_OPTIONS } from './symbols';
+import { NgxsLocalStoragePluginOptions, NGXS_LOCAL_STORAGE_PLUGIN_OPTIONS } from './symbols';
 
 @NgModule()
-export class LocalStoragePluginModule {
-  static forRoot(options: LocalStoragePluginOptions = {}): ModuleWithProviders {
+export class NgxsLocalStoragePluginModule {
+  static forRoot(options: NgxsLocalStoragePluginOptions = {}): ModuleWithProviders {
     return {
-      ngModule: LocalStoragePluginModule,
+      ngModule: NgxsLocalStoragePluginModule,
       providers: [
         {
           provide: NGXS_PLUGINS,
-          useClass: LocalStoragePlugin,
+          useClass: NgxsLocalStoragePlugin,
           multi: true
         },
         {
-          provide: LOCAL_STORAGE_PLUGIN_OPTIONS,
+          provide: NGXS_LOCAL_STORAGE_PLUGIN_OPTIONS,
           useValue: {
             key: options.key || '@@STATE',
             storage: localStorage,

--- a/src/plugins/localstorage/localstorage.plugin.spec.ts
+++ b/src/plugins/localstorage/localstorage.plugin.spec.ts
@@ -4,9 +4,9 @@ import { NgxsModule } from '../../module';
 import { State } from '../../state';
 import { Store } from '../../store';
 import { Action } from '../../action';
-import { LocalStoragePluginModule } from './localstorage.module';
+import { NgxsLocalStoragePluginModule } from './localstorage.module';
 
-describe('LocalStoragePlugin', () => {
+describe('NgxsLocalStoragePlugin', () => {
   let store: Store;
 
   class Increment {}
@@ -43,7 +43,7 @@ describe('LocalStoragePlugin', () => {
     localStorage.setItem('@@STATE', JSON.stringify({ counter: { count: 100 } }));
 
     TestBed.configureTestingModule({
-      imports: [LocalStoragePluginModule.forRoot(), NgxsModule.forRoot([MyStore])]
+      imports: [NgxsLocalStoragePluginModule.forRoot(), NgxsModule.forRoot([MyStore])]
     });
 
     store = TestBed.get(Store);

--- a/src/plugins/localstorage/localstorage.plugin.ts
+++ b/src/plugins/localstorage/localstorage.plugin.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
 import { NgxsPlugin } from '../../symbols';
-import { LocalStoragePluginOptions, LOCAL_STORAGE_PLUGIN_OPTIONS } from './symbols';
+import { NgxsLocalStoragePluginOptions, NGXS_LOCAL_STORAGE_PLUGIN_OPTIONS } from './symbols';
 import { getTypeFromInstance, setValue, getValue } from '../../internals';
 import { tap } from 'rxjs/operators';
 
 @Injectable()
-export class LocalStoragePlugin implements NgxsPlugin {
-  constructor(@Inject(LOCAL_STORAGE_PLUGIN_OPTIONS) private _options: LocalStoragePluginOptions) {}
+export class NgxsLocalStoragePlugin implements NgxsPlugin {
+  constructor(@Inject(NGXS_LOCAL_STORAGE_PLUGIN_OPTIONS) private _options: NgxsLocalStoragePluginOptions) {}
 
   handle(state, event, next) {
     const options = this._options || <any>{};

--- a/src/plugins/localstorage/symbols.ts
+++ b/src/plugins/localstorage/symbols.ts
@@ -1,10 +1,10 @@
 import { InjectionToken } from '@angular/core';
 
-export interface LocalStoragePluginOptions {
+export interface NgxsLocalStoragePluginOptions {
   key?: string | string[] | undefined;
   storage?: any;
   serialize?(obj: any);
   deserialize?(obj: any);
 }
 
-export const LOCAL_STORAGE_PLUGIN_OPTIONS = new InjectionToken('LOCAL_STORAGE_PLUGIN_OPTION');
+export const NGXS_LOCAL_STORAGE_PLUGIN_OPTIONS = new InjectionToken('NGXS_LOCAL_STORAGE_PLUGIN_OPTION');

--- a/src/plugins/logger/index.ts
+++ b/src/plugins/logger/index.ts
@@ -1,2 +1,2 @@
-export { LoggerPluginModule } from './logger.module';
-export { LoggerPlugin } from './logger.plugin';
+export { NgxsLoggerPluginModule } from './logger.module';
+export { NgxsLoggerPlugin } from './logger.plugin';

--- a/src/plugins/logger/logger.module.ts
+++ b/src/plugins/logger/logger.module.ts
@@ -1,21 +1,21 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
-import { LoggerPluginOptions, LOGGER_PLUGIN_OPTIONS } from './symbols';
+import { NgxsLoggerPluginOptions, NGXS_LOGGER_PLUGIN_OPTIONS } from './symbols';
 import { NGXS_PLUGINS } from '../../symbols';
-import { LoggerPlugin } from './logger.plugin';
+import { NgxsLoggerPlugin } from './logger.plugin';
 
 @NgModule()
-export class LoggerPluginModule {
-  static forRoot(options: LoggerPluginOptions): ModuleWithProviders {
+export class NgxsLoggerPluginModule {
+  static forRoot(options: NgxsLoggerPluginOptions): ModuleWithProviders {
     return {
-      ngModule: LoggerPluginModule,
+      ngModule: NgxsLoggerPluginModule,
       providers: [
         {
           provide: NGXS_PLUGINS,
-          useClass: LoggerPlugin,
+          useClass: NgxsLoggerPlugin,
           multi: true
         },
         {
-          provide: LOGGER_PLUGIN_OPTIONS,
+          provide: NGXS_LOGGER_PLUGIN_OPTIONS,
           useValue: {
             ...{
               logger: console,

--- a/src/plugins/logger/logger.plugin.ts
+++ b/src/plugins/logger/logger.plugin.ts
@@ -1,13 +1,13 @@
 import { Injectable, Inject } from '@angular/core';
 import { NgxsPlugin } from '../../symbols';
-import { LOGGER_PLUGIN_OPTIONS, LoggerPluginOptions } from './symbols';
+import { NGXS_LOGGER_PLUGIN_OPTIONS, NgxsLoggerPluginOptions } from './symbols';
 import { pad } from './internals';
 import { tap } from 'rxjs/operators';
 import { getTypeFromInstance } from '../../internals';
 
 @Injectable()
-export class LoggerPlugin implements NgxsPlugin {
-  constructor(@Inject(LOGGER_PLUGIN_OPTIONS) private _options: LoggerPluginOptions) {}
+export class NgxsLoggerPlugin implements NgxsPlugin {
+  constructor(@Inject(NGXS_LOGGER_PLUGIN_OPTIONS) private _options: NgxsLoggerPluginOptions) {}
 
   handle(state, event, next) {
     const options = this._options || <any>{};

--- a/src/plugins/logger/symbols.ts
+++ b/src/plugins/logger/symbols.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@angular/core';
 
-export interface LoggerPluginOptions {
+export interface NgxsLoggerPluginOptions {
   /** Auto expand logged mutations  */
   collapsed: boolean;
 
@@ -8,4 +8,4 @@ export interface LoggerPluginOptions {
   logger: any;
 }
 
-export const LOGGER_PLUGIN_OPTIONS = new InjectionToken('LOGGER_PLUGIN_OPTIONS');
+export const NGXS_LOGGER_PLUGIN_OPTIONS = new InjectionToken('NGXS_LOGGER_PLUGIN_OPTIONS');


### PR DESCRIPTION
Rename plugin modules and classes to include Ngxs prefix
closes #87 


BREAKING CHANGE:

`LoggerPlugin` is now `NgxsLoggerPlugin`
`LoggerPluginModule` is now `NgxsLoggerPluginModule`
`LocalStoragePlugin` is now `NgxsLocalStoragePlugin`
`LocalStoragePluginModule` is now `NgxsLocalStoragePluginModule`
`ReduxDevtoolsPlugin` is now `NgxsReduxDevtoolsPlugin`
`ReduxDevtoolsPluginModule` is now `NgxsReduxDevtoolsPluginModule`