### PR TITLE
Missing getState() call before patchValues

### DIFF
--- a/docs/concepts/state.md
+++ b/docs/concepts/state.md
@@ -115,6 +115,7 @@ could be reduced to this:
 ```TS
 @Action(FeedAnimals)
   feedAnimals({ getState, patchValue }: StateContext<ZooStateModel>, { payload }: FeedAnimals) {
+  const state = getState();
   patchValue({
     feedAnimals: [ ...state.feedAnimals, payload ]
   });


### PR DESCRIPTION
Fixes a `[ts] Cannot find name 'state'.` error.  This tripped me up for a couple minutes.