### PR TITLE
feat: improved module init

### DIFF
--- a/docs/concepts/state.md
+++ b/docs/concepts/state.md
@@ -115,6 +115,7 @@ could be reduced to this:
 ```TS
 @Action(FeedAnimals)
   feedAnimals({ getState, patchValue }: StateContext<ZooStateModel>, { payload }: FeedAnimals) {
+  const state = getState();
   patchValue({
     feedAnimals: [ ...state.feedAnimals, payload ]
   });

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -21,7 +21,7 @@ export class LoggerPlugin implements NgxsPlugin {
 
   handle(state, action, next) {
     console.log('Action started!', state);
-    return next(state, mutation).pipe(tap(result) => {
+    return next(state, action).pipe(tap(result) => {
       console.log('Action happened!', result);
     });
   }
@@ -54,7 +54,7 @@ would look like this:
 ```javascript
 export function logPlugin(state, action, next) {
   console.log('Action started!', state);
-  return next(state, mutation).pipe(tap(result) => {
+  return next(state, action).pipe(tap(result) => {
     console.log('Action happened!', result);
   });
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "ng serve --aot",
+    "start:integration": "ng serve --aot --app 1",
     "test": "ng test",
     "test:integration":
       "npm run build && npm link ./dist && ng test --preserve-symlinks --app 1 -sr --browsers ChromeHeadless &&  ng build --preserve-symlinks --app 1 --prod",

--- a/src/actions/init.ts
+++ b/src/actions/init.ts
@@ -1,3 +1,3 @@
-export class InitStore {
+export class InitState {
   static readonly type = '@@INIT';
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,13 +1,13 @@
-import { NgModule, ModuleWithProviders, Optional, Inject, SkipSelf } from '@angular/core';
+import { NgModule, ModuleWithProviders, Optional, Inject } from '@angular/core';
 
-import { STORE_TOKEN } from './symbols';
+import { ROOT_STATE_TOKEN, FEATURE_STATE_TOKEN } from './symbols';
 import { StateFactory } from './state-factory';
 import { Actions } from './actions-stream';
 import { Store } from './store';
 import { SelectFactory } from './select';
 import { StateStream } from './state-stream';
 import { PluginManager } from './plugin-manager';
-import { InitStore } from './actions/init';
+import { InitState } from './actions/init';
 
 @NgModule()
 export class NgxsRootModule {
@@ -17,16 +17,23 @@ export class NgxsRootModule {
     store: Store,
     select: SelectFactory,
     @Optional()
-    @Inject(STORE_TOKEN)
-    stores: any[]
+    @Inject(ROOT_STATE_TOKEN)
+    states: any[]
   ) {
-    this.initStores(stores);
-    store.dispatch(new InitStore());
+    this.initStates(states);
+    store.dispatch(new InitState());
   }
 
-  initStores(stores) {
-    if (stores) {
-      const init = this._factory.addAndReturnDefaults(stores);
+  initStates(states) {
+    if (states) {
+      if (!this._stateStream) {
+        throw new Error(
+          // tslint:disable-next-line
+          `'NgxsModule.forRoot()' was not called at the root module. Please add it to the root module even if you don't have any root states.`
+        );
+      }
+      // add stores to the state graph and return their defaults
+      const init = this._factory.addAndReturnDefaults(states);
 
       // get our current stream
       const cur = this._stateStream.getValue();
@@ -40,40 +47,21 @@ export class NgxsRootModule {
 @NgModule({})
 export class NgxsFeatureModule {
   constructor(
+    root: NgxsRootModule,
+    store: Store,
     @Optional()
-    @SkipSelf()
-    private _stateStream: StateStream,
-    private _factory: StateFactory,
-    @Optional()
-    @Inject(STORE_TOKEN)
-    stores: any[]
+    @Inject(FEATURE_STATE_TOKEN)
+    states: any[][]
   ) {
-    this.initStores(stores);
-  }
-
-  initStores(stores) {
-    if (stores) {
-      if (!this._stateStream) {
-        throw new Error(`
-          'NgxsModule.forRoot()' was not called at the root module.
-          Please add it to the root module even if you don't have any root states.`);
-      }
-
-      // bind the stores
-      const init = this._factory.addAndReturnDefaults(stores);
-
-      // get our current stream
-      const cur = this._stateStream.getValue();
-
-      // set the state to the current + new
-      this._stateStream.next({ ...cur, ...init });
-    }
+    // since FEATURE_STATE_TOKEN is a multi token, we need to flatten it [[Feature1State, Feature2State], [Feature3State]]
+    const flattenedStates = ([] as any[]).concat(...states);
+    root.initStates(flattenedStates);
   }
 }
 
 @NgModule({})
 export class NgxsModule {
-  static forRoot(stores: any[]): ModuleWithProviders {
+  static forRoot(states: any[] = []): ModuleWithProviders {
     return {
       ngModule: NgxsRootModule,
       providers: [
@@ -83,25 +71,26 @@ export class NgxsModule {
         StateStream,
         SelectFactory,
         PluginManager,
-        stores,
+        ...states,
         {
-          provide: STORE_TOKEN,
-          useValue: stores
+          provide: ROOT_STATE_TOKEN,
+          useValue: states
         }
       ]
     };
   }
 
-  static forFeature(stores: any[]): ModuleWithProviders {
+  static forFeature(states: any[]): ModuleWithProviders {
     return {
       ngModule: NgxsFeatureModule,
       providers: [
-        stores,
         StateFactory,
         PluginManager,
+        ...states,
         {
-          provide: STORE_TOKEN,
-          useValue: stores
+          provide: FEATURE_STATE_TOKEN,
+          multi: true,
+          useValue: states
         }
       ]
     };

--- a/src/spec/module.spec.ts
+++ b/src/spec/module.spec.ts
@@ -1,0 +1,101 @@
+import { NgModule } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { NgxsModule, Store } from 'ngxs';
+
+import { State } from '../state';
+
+interface RootStateModel {
+  foo: string;
+}
+@State<RootStateModel>({
+  name: 'root',
+  defaults: {
+    foo: 'Hello'
+  }
+})
+class RootState {}
+
+interface FeatureStateModel {
+  bar: string;
+}
+@State<FeatureStateModel>({
+  name: 'feature',
+  defaults: {
+    bar: 'World'
+  }
+})
+class FeatureState {}
+
+interface FeatureStateModel2 {
+  baz: string;
+}
+@State<FeatureStateModel2>({
+  name: 'feature2',
+  defaults: {
+    baz: '!'
+  }
+})
+class FeatureState2 {}
+
+@NgModule({
+  imports: [NgxsModule.forRoot([RootState])]
+})
+class RootModule {}
+
+@NgModule({
+  imports: [NgxsModule.forFeature([FeatureState])]
+})
+class FeatureModule {}
+
+@NgModule({
+  imports: [NgxsModule.forFeature([FeatureState])]
+})
+class FeatureModule2 {}
+
+describe('module', () => {
+  it('should configure and run with no states', () => {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot()]
+    });
+
+    expect(TestBed.get(Store)).toBeTruthy();
+  });
+
+  it('should configure and return `RootState`', () => {
+    TestBed.configureTestingModule({
+      imports: [RootModule]
+    });
+
+    expect(TestBed.get(Store)).toBeTruthy();
+    expect(TestBed.get(RootState)).toBeTruthy();
+  });
+
+  it('should configure feature module and return `RootState` and `FeatureState`', () => {
+    TestBed.configureTestingModule({
+      imports: [RootModule, FeatureModule]
+    });
+
+    expect(TestBed.get(Store)).toBeTruthy();
+    expect(TestBed.get(RootState)).toBeTruthy();
+    expect(TestBed.get(FeatureModule)).toBeTruthy();
+  });
+
+  it('should configure feature modules and return them', () => {
+    TestBed.configureTestingModule({
+      imports: [RootModule, FeatureModule, FeatureModule2]
+    });
+
+    expect(TestBed.get(Store)).toBeTruthy();
+    expect(TestBed.get(RootState)).toBeTruthy();
+    expect(TestBed.get(FeatureModule, FeatureState2)).toBeTruthy();
+  });
+
+  it('should allow empty root module and a feature module', () => {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot(), FeatureModule]
+    });
+
+    expect(TestBed.get(Store)).toBeTruthy();
+    expect(TestBed.get(FeatureModule)).toBeTruthy();
+  });
+});

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,8 +1,8 @@
 import { InjectionToken } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
-export const STORE_TOKEN = new InjectionToken<any>('STORE_TOKEN');
-export const STORE_OPTIONS_TOKEN = new InjectionToken<any>('STORE_OPTIONS_TOKEN');
+export const ROOT_STATE_TOKEN = new InjectionToken<any>('ROOT_STATE_TOKEN');
+export const FEATURE_STATE_TOKEN = new InjectionToken<any>('FEATURE_STATE_TOKEN');
 export const META_KEY = 'NGXS_META';
 
 export type NgxsPluginConstructor = new (...args: any[]) => NgxsPlugin;


### PR DESCRIPTION
I was having troubles when having `NgxsModule.forFeature` in the main app.

It seems that the provider store token was being injected multiple times which caused feature's to be loaded twice.

By separating out the feature states into it's own token it seems to be working better.

I Also added some units tests to test out the different setups we can encounter.

The pull request is also tested against `--aot` and everything seems to be working.
@amcdnl  Could you have a look and see if this improves things?